### PR TITLE
Expand config value strings before updating destination property

### DIFF
--- a/private/Update-PropertiesFromCsvFile.ps1
+++ b/private/Update-PropertiesFromCsvFile.ps1
@@ -31,7 +31,8 @@ function Update-PropertiesFromCsvFile {
         $newFile = $file
         Write-Debug "File: $file"
         $json = (Get-Content $file | ConvertFrom-Json)
-        $prop = "$($_.name).properties.$($_.path) = `"$($_.value)`""
+        $newValue = $ExecutionContext.InvokeCommand.ExpandString($_.value)
+        $prop = "$($_.name).properties.$($_.path) = `"$($newValue)`""
         Write-Verbose "- $prop"
         Invoke-Expression "`$json.properties.$($_.path) = `"$($_.value)`""
         $json | ConvertTo-Json -Depth 10 | Out-File $newFile -Encoding ascii


### PR DESCRIPTION
It's a one-line nicety - allows PS functions within config values to be evaluated. 

e.g. "version-timestamp-$(Get-Date -Format yyyy-MM-dd)" would be updated to "version-timestamp-2020-05-21"

Also allows for things like env variables to be accessed at runtime and incorporated into config values.