### PR TITLE
Unused datasets collab

### DIFF
--- a/private/Adf.class.ps1
+++ b/private/Adf.class.ps1
@@ -55,17 +55,23 @@ class Adf {
         $this.DataSets | ForEach-Object {
             $null = $dataset_list.Add($_.Name) 
         }
-        # iterate over pipelines content looking for dataset names
-        foreach($pipe in $this.Pipelines.FileName){
-            $stringPipe = Get-Content $pipe
+        # iterate over pipelines and dataflows content looking for dataset names
+        foreach($pipe in $this.Pipelines.FileName + $this.DataFlows.FileName){
+            $stringContent = Get-Content $pipe
             For ($i=0; $i -lt $dataset_list.Count; $i++) {
                 # if the dataset is being used, replace it with ''
-                if($stringPipe -match $dataset_list[$i]){
+                if($stringContent -match $dataset_list[$i]){
                     $dataset_list[$i] = ''
                 }
             }
-            # remove used datasets from the list
-            $dataset_list = $dataset_list | Where-Object { $_ –ne '' }
+            # remove used datasets from the list, try will fail with the last object
+            # so it goes to the catch when cleaning the list.
+            try{
+                $dataset_list = $dataset_list | Where-Object { $_ –ne '' }
+            }
+            catch{
+                $dataset_list.Remove('')
+            }
         }
         # datasets not removed from the list are the ones not being used
         return $dataset_list

--- a/private/Adf.class.ps1
+++ b/private/Adf.class.ps1
@@ -49,5 +49,28 @@ class Adf {
         return $r
     }
 
+    [System.Collections.ArrayList] GetUnusedDatasets()
+    {
+        [System.Collections.ArrayList] $dataset_list = @{}
+        $this.DataSets | ForEach-Object {
+            $null = $dataset_list.Add($_.Name) 
+        }
+        # iterate over pipelines content looking for dataset names
+        foreach($pipe in $this.Pipelines.FileName){
+            $stringPipe = Get-Content $pipe
+            For ($i=0; $i -lt $dataset_list.Count; $i++) {
+                # if the dataset is being used, replace it with ''
+                if($stringPipe -match $dataset_list[$i]){
+                    $dataset_list[$i] = ''
+                }
+            }
+            # remove used datasets from the list
+            $dataset_list = $dataset_list | Where-Object { $_ –ne '' }
+        }
+        # datasets not removed from the list are the ones not being used
+        return $dataset_list
+    }   
+
+
 }
 

--- a/private/Remove-UnusedDatasetsFromAdf.ps1
+++ b/private/Remove-UnusedDatasetsFromAdf.ps1
@@ -1,0 +1,12 @@
+function Remove-UnusedDatasetsFromAdf {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)] [Adf] $Adf,
+        [Parameter(Mandatory = $false)] [switch] $SoftDelete
+    )
+
+    
+    
+
+
+}

--- a/private/Remove-UnusedDatasetsFromAdf.ps1
+++ b/private/Remove-UnusedDatasetsFromAdf.ps1
@@ -5,8 +5,19 @@ function Remove-UnusedDatasetsFromAdf {
         [Parameter(Mandatory = $false)] [switch] $SoftDelete
     )
 
+    $dataset_list = $Adf.GetUnusedDatasets()
     
-    
+    foreach($dataset_name in $dataset_list){
+        # get the dataset object
+        $obj = Get-AdfObjectByName -adf $Adf -type "Dataset" -name $dataset_name
 
+        # remove it from the ADF object
+        $Adf.DataSets.Remove($obj)
+
+        # if softdelete is not activated, then also delete the json file.
+        if(!$SoftDelete){
+            Remove-Item $obj.FileName
+        }
+    }
 
 }


### PR DESCRIPTION
Added method GetUnusedDatasets() to Adf class, which iterates over pipelines and dataflows looking for dataset names, and returns those that were not found.

Also added the cmdlet Remove-UnusedDatasetsFromAdf that remove those datasets returned by the previous method from the Adf object. The SoftDelete switch controls if the actual json file is deleted or not (when activated, it doesnt remove the file).