### PR TITLE
Param bug - $DataFactoryName renamed to $FactoryName in Get-AdfFromService

### DIFF
--- a/public/Get-AdfFromService.ps1
+++ b/public/Get-AdfFromService.ps1
@@ -32,22 +32,22 @@ function Get-AdfFromService {
     $adf.Name = $FactoryName
     $adf.ResourceGroupName = $ResourceGroupName
 
-    $adfi = Get-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$DataFactoryName"
+    $adfi = Get-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$FactoryName"
     Write-Host ("Azure Data Factory (instance) loaded." -f $adf.DataSets.Count)
     $adf.Id = $adfi.DataFactoryId
     $adf.Location = $adfi.Location
 
-    $adf.DataSets = Get-AzDataFactoryV2Dataset -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.DataSets = Get-AzDataFactoryV2Dataset -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("DataSets: {0} object(s) loaded." -f $adf.DataSets.Count)
-    $adf.IntegrationRuntimes = Get-AzDataFactoryV2IntegrationRuntime -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.IntegrationRuntimes = Get-AzDataFactoryV2IntegrationRuntime -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("IntegrationRuntimes: {0} object(s) loaded." -f $adf.IntegrationRuntimes.Count)
-    $adf.LinkedServices = Get-AzDataFactoryV2LinkedService -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.LinkedServices = Get-AzDataFactoryV2LinkedService -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("LinkedServices: {0} object(s) loaded." -f $adf.LinkedServices.Count)
-    $adf.Pipelines = Get-AzDataFactoryV2Pipeline -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.Pipelines = Get-AzDataFactoryV2Pipeline -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("Pipelines: {0} object(s) loaded." -f $adf.Pipelines.Count)
-    $adf.DataFlows = Get-AzDataFactoryV2DataFlow -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.DataFlows = Get-AzDataFactoryV2DataFlow -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("DataFlows: {0} object(s) loaded." -f $adf.DataFlows.Count)
-    $adf.Triggers = Get-AzDataFactoryV2Trigger -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$DataFactoryName" | ToArray
+    $adf.Triggers = Get-AzDataFactoryV2Trigger -ResourceGroupName "$ResourceGroupName" -DataFactoryName "$FactoryName" | ToArray
     Write-Host ("Triggers: {0} object(s) loaded." -f $adf.Triggers.Count)
 
     Write-Debug "END: Get-AdfFromService()"


### PR DESCRIPTION
When used by with example and parent cmdlet $DataFactoryName is declared so no issue. When used in isolation internal param mapping is invalid.