### PR TITLE
Fix for issue #67

### DIFF
--- a/private/AdfInstance.class.ps1
+++ b/private/AdfInstance.class.ps1
@@ -12,6 +12,6 @@ class AdfInstance {
 
     [System.Collections.ArrayList] AllObjects()
     {
-        return $this.LinkedServices + $this.Pipelines + $this.DataSets + $this.DataFlows + $this.Triggers + $this.IntegrationRuntimes
+        return $this.Triggers + $this.Pipelines + $this.DataFlows + $this.DataSets + $this.LinkedServices + $this.IntegrationRuntimes
     }
 }


### PR DESCRIPTION
Change in AdfInstance.class.ps1 that should fix issue #67 by changing the way "AllObjects()" method builds and returns the List of all Adf Objects.

In this way, when in [Publish-AdfV2FromJson.ps1](https://github.com/SQLPlayer/azure.datafactory.tools/blob/ea303fb5e15007757c117f8ba892abf96c09a8f8/public/Publish-AdfV2FromJson.ps1#L189), the Adf Objects would be ordered by dependency hierarchy, described as follows: Triggers **run** Pipelines/Dataflows **that contain** Datasets **referring to** Linked Services, **runs on** IntegrationRuntimes.

In this way the Adf Objects would get deleted from up to bottom, starting from those with no dependancies, to those with more.