### PR TITLE
Stop trigger before deployment if started

### DIFF
--- a/private/Deploy-AdfObject.ps1
+++ b/private/Deploy-AdfObject.ps1
@@ -17,6 +17,23 @@ function Deploy-AdfObject {
 
     $adf = $obj.Adf
 
+    $activeTriggersADF = Get-SortedTriggers -DataFactoryName $adf.Name -ResourceGroupName $adf.ResourceGroupName `
+    | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+
+    if($obj.Type -match "Trigger")
+    {   
+        $activeTriggersADF | ForEach-Object {
+            if($obj.Name -like $_.Name) {
+                Stop-AzDataFactoryV2Trigger `
+                -ResourceGroupName $ResourceGroupName `
+                -DataFactoryName $DataFactoryName `
+                -Name $obj.Name `
+                -Force | Out-Null
+                Write-Host "Trigger [$($obj.name)] is Started"
+                Write-Host "Stopping Trigger before deployment: [$($obj.name)]"
+            }
+        }
+    }
     if ($obj.DependsOn.Count -gt 0)
     {
         Write-Debug "Checking all dependencies of [$($obj.Name)]..."
@@ -36,6 +53,20 @@ function Deploy-AdfObject {
     }
 
     Deploy-AdfObjectOnly -obj $obj
+
+    if($obj.Type -match "Trigger")
+    {
+        $activeTriggersADF | ForEach-Object {
+            if($obj.Name -like $_.Name) {
+                Start-AzDataFactoryV2Trigger `
+                -ResourceGroupName $ResourceGroupName `
+                -DataFactoryName $DataFactoryName `
+                -Name $obj.Name `
+                -Force | Out-Null
+                Write-Host "Starting Tigger after deployment: [$($obj.name)]"
+            }
+        }
+    }
 
     Write-Host "Finished deploying object [$($obj.Name)]."
 


### PR DESCRIPTION
Fix for #71 
Stop trigger before trigger deployment if it's started in target Data Factory, and start again to restore it's previous state