### PR TITLE
Add option to index into arrays by element name - Issue #98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# azure.datafactory.tools specific items
+**/TEST-Results.xml
+
 # User-specific files
 *.suo
 *.user

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Powershell Debug Unit Tests",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${workspaceRoot}/test/!RunAllTests.ps1 -Verbose",
+            "cwd": "${workspaceRoot}",
+            "args": [
+                "${workspaceRoot}"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ Additionally, you can **remove** selected property altogether or **create (add)*
 * `+` (plus) - Add new property with defined value
 * `-` (minus) - Remove existing property  
 
+When using paths that reference items within an array, you have two options for keying into the array:
+* Integer key (0 based)
+* If all items in the array have the property ```name```, we can use that value as the key, eg for pipeline activities.
+
 See example below:
 ```
 type,name,path,value
@@ -356,6 +360,9 @@ linkedService,BlobSampleData,+typeProperties.accountKey,"$($Env:VARIABLE)"
 factory,BigFactorySample2,"$.properties.globalParameters.'Env-Code'.value","PROD"
 # Multiple following configurations for many files:
 dataset,DS_SQL_*,properties.xyz,ABC
+# Change a pipeline activity timeout using integer and name based indexers
+pipeline,PL_Demo,activities[1].typeProperties.waitTimeInSeconds,30
+pipeline,PL_Demo,activities["Copy Data"].typeProperties.waitTimeInSeconds,30
 ```
 
 
@@ -434,6 +441,18 @@ If you prefer using JSON rather than CSV for setting up configuration - JSON fil
     {
       "name": "$.properties.typeProperties.baseUrl",
       "value": "https://kv-$($Env:Environment).vault.azure.net/",
+      "action": "update"
+    }
+  ],
+  "PL_Demo": [
+    {
+      "name": "$.activities[1].typeProperties.waitTimeInSeconds",
+      "value": "30",
+      "action": "update"
+    },
+    {
+      "name": "$.activities["Copy Data"].typeProperties.waitTimeInSeconds",
+      "value": "30",
       "action": "update"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ If you prefer using JSON rather than CSV for setting up configuration - JSON fil
       "action": "update"
     },
     {
-      "name": "$.activities["Copy Data"].typeProperties.waitTimeInSeconds",
+      "name": "$.activities['Copy Data'].typeProperties.waitTimeInSeconds",
       "value": "30",
       "action": "update"
     }

--- a/private/ConvertFrom-ArraysToOrderedHashTables.ps1
+++ b/private/ConvertFrom-ArraysToOrderedHashTables.ps1
@@ -17,6 +17,10 @@ function ConvertFrom-ArraysToOrderedHashTables {
         # Loop through the properties, changing arrays and processing PSCustomObject's
         foreach ($prop in $Item.PSObject.Properties.Name) {
 
+            if ($Item.$prop -eq $null){
+                Write-Verbose "Skipping property '$prop' as type cannot be determined for null";
+                continue;
+            }
             Write-Verbose "Processing property '$prop' of type  $($Item.$prop.GetType().Name)";
 
             # If the current property is a non-empty array
@@ -24,11 +28,10 @@ function ConvertFrom-ArraysToOrderedHashTables {
             
                 $itemCount = $Item.$prop.Count;
                 foreach ($idProp in $arrayIdProps) {
-                    $matchedItemCount = $Item.$prop.Where({$_.PSobject.Properties.Name -contains $idProp}, 'Default').Count;
+                    # If the item in the array is a primitive type, calling PSobject.Properties.Name will throw...
+                    $matchedItemCount = $Item.$prop.Where({ (-not $_.GetType().IsPrimitive) -and $_.PSobject.Properties.Name -contains $idProp }, 'Default').Count;
 
                     if ( $matchedItemCount -eq $itemCount ) {
-                    #if ( $Item.$prop[0].$idProp -notcontains $null ) {
-                    #if ( $Item.$prop.PSobject.Properties.Name -contains $idProp) {
                         Write-Verbose "Extracting ordered hash table from array using property $idProp as the key";
                         
                         # First convert each item in the array to have ordered hashtables instead of arrays if required

--- a/private/ConvertFrom-ArraysToOrderedHashTables.ps1
+++ b/private/ConvertFrom-ArraysToOrderedHashTables.ps1
@@ -1,0 +1,85 @@
+function ConvertFrom-ArraysToOrderedHashTables {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)] $Item,
+        # This determines the arrays that are converted to OrderedHashTables. Only arrays where the objects have a property
+        # with one of the values in this array can be converted, using that property as the key
+        [parameter(Mandatory = $false)] [String[]] $ArrayIdProps = @("name", "Name")
+    )
+
+    Write-Verbose "Entering Function: ConvertFrom-ArraysToOrderedHashTables";
+
+    if ( $Item.GetType().Name -eq "PSCustomObject" ) {
+
+        Write-Verbose "Processing PSCustomObject...";
+        Write-Verbose "Properties: $($Item.PSObject.Properties.Name)";
+
+        # Loop through the properties, changing arrays and processing PSCustomObject's
+        foreach ($prop in $Item.PSObject.Properties.Name) {
+
+            Write-Verbose "Processing property '$prop' of type  $($Item.$prop.GetType().Name)";
+
+            # If the current property is a non-empty array
+            if ( $Item.$prop.GetType().Name -eq "Object[]" -and $Item.$prop.Count -gt 0) {
+            
+                $itemCount = $Item.$prop.Count;
+                foreach ($idProp in $arrayIdProps) {
+                    $matchedItemCount = $Item.$prop.Where({$_.PSobject.Properties.Name -contains $idProp}, 'Default').Count;
+
+                    if ( $matchedItemCount -eq $itemCount ) {
+                    #if ( $Item.$prop[0].$idProp -notcontains $null ) {
+                    #if ( $Item.$prop.PSobject.Properties.Name -contains $idProp) {
+                        Write-Verbose "Extracting ordered hash table from array using property $idProp as the key";
+                        
+                        # First convert each item in the array to have ordered hashtables instead of arrays if required
+                        for ($i=0; $i -lt $itemCount; $i++ ){
+                            $Item.$prop[$i] = ConvertFrom-ArraysToOrderedHashTables -Item $Item.$prop[$i];
+                        }
+                        # Then convert the actual array to a ordered hashtables
+                        $Item.$prop = ArrayToOrderedHash -Array $Item.$prop -KeyProperty $idProp -Verbose:$VerbosePreference;
+                        
+                        break;
+                    }
+                }
+            }
+
+            elseif ( $Item.$prop.GetType().Name -eq "PSCustomObject" ) {
+                Write-Verbose "Converting PSCustomObject property using a recursive function call...";
+
+                $Item.$prop = ConvertFrom-ArraysToOrderedHashTables -Item $Item.$prop;
+            }
+        }
+
+        return $Item;
+    }
+    elseif ( $Item.GetType().BaseType -eq "Object[]" ) {
+        Write-Verbose "Processing Array...";
+
+        $wrapper = [PSCustomObject]@{
+            WrappedObject = $Item
+        }
+
+        $result = ConvertFrom-ArraysToOrderedHashTables -obj $wrapper;
+        return $result.WrappedObject;
+    }
+    else {
+        Write-Verbose "Unknown input object type, not supportted";
+        return $Item;
+    }
+}
+
+function ArrayToOrderedHash {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)] [System.Array] $Array,
+        [parameter(Mandatory = $true)] [String] $KeyProperty
+    )
+
+    Write-Verbose "Entering Function: ArrayToOrderedHash";
+   
+    Write-Verbose "Key property: $keyProperty";
+
+    $hash = [ordered]@{};
+    $array | ForEach-Object { $hash[$_.$keyProperty] = $_ };
+    return $hash;
+}

--- a/private/ConvertFrom-OrderedHashTablesToArrays.ps1
+++ b/private/ConvertFrom-OrderedHashTablesToArrays.ps1
@@ -13,6 +13,10 @@ function ConvertFrom-OrderedHashTablesToArrays {
 
         # Loop through the properties, changing arrays and processing PSCustomObject's
         foreach ($prop in $Item.PSObject.Properties.Name) {
+            if ($Item.$prop -eq $null){
+                Write-Verbose "Skipping property '$prop' as type cannot be determined for null";
+                continue;
+            }
 
             Write-Verbose "Processing property '$prop' of type  $($Item.$prop.GetType().Name)";
 

--- a/private/ConvertFrom-OrderedHashTablesToArrays.ps1
+++ b/private/ConvertFrom-OrderedHashTablesToArrays.ps1
@@ -1,0 +1,56 @@
+function ConvertFrom-OrderedHashTablesToArrays {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)] $Item
+    )
+
+    Write-Verbose "Entering Function: ConvertFrom-OrderedHashTablesToArrays";
+
+    if ( $Item.GetType().Name -eq "PSCustomObject" ) {
+
+        Write-Verbose "Processing PSCustomObject...";
+        Write-Verbose "Properties: $($Item.PSObject.Properties.Name)";
+
+        # Loop through the properties, changing arrays and processing PSCustomObject's
+        foreach ($prop in $Item.PSObject.Properties.Name) {
+
+            Write-Verbose "Processing property '$prop' of type  $($Item.$prop.GetType().Name)";
+
+            if ( $Item.$prop.GetType().Name -eq "OrderedDictionary" ) {
+            
+                Write-Verbose "Converting ordered hash table to array";
+
+                # First convert each item in the array to have ordered hashtables instead of arrays if required
+                for ($i=0; $i -lt $Item.$prop.Count; $i++ ){
+                    $Item.$prop[$i] = ConvertFrom-OrderedHashTablesToArrays -Item $Item.$prop[$i];
+                }
+                # Then convert the actual array to a ordered hashtables
+
+                # Without the ForEach-Object we get a OrderedDictionaryKeyValueCollection back, which is not too useful. We need an array, or the JSON
+                # gets saved using the keys as properties instead of an array. The foreeach unboxes back to an array for us.
+                $Item.$prop = $Item.$prop.Values | ForEach-Object { $_ };
+            }
+            elseif ( $Item.$prop.GetType().Name -eq "PSCustomObject" ) {
+                Write-Verbose "Converting PSCustomObject property using a recursive function call...";
+
+                $Item.$prop = ConvertFrom-OrderedHashTablesToArrays -Item $Item.$prop;
+            }
+        }
+
+        return $Item;
+    }
+    elseif ( $Item.GetType().BaseType -eq "OrderedDictionary" ) {
+        Write-Verbose "Processing Array...";
+
+        $wrapper = [PSCustomObject]@{
+            WrappedObject = $Item
+        }
+
+        $result = ConvertFrom-OrderedHashTablesToArrays -obj $wrapper;
+        return $result.WrappedObject;
+    }
+    else {
+        Write-Verbose "Unknown input object type, not supportted";
+        return $Item;
+    }
+}

--- a/private/Update-PropertiesFromFile.ps1
+++ b/private/Update-PropertiesFromFile.ps1
@@ -100,7 +100,7 @@ function Update-PropertiesForObject {
     # if ($null -eq $o -and $action -ne "add") {
     #     Write-Error "ADFT0008: Could not find object: $type.$name"
     # }
-    $json = $o.Body
+    $json = $o.Body | ConvertFrom-ArraysToOrderedHashTables
     if ($null -eq $json) {
         Write-Error "ADFT0009: Body of the object is empty!"
     }
@@ -148,6 +148,8 @@ function Update-PropertiesForObject {
             }
         }
     }
+
+    $o.Body = $json | ConvertFrom-OrderedHashTablesToArrays
 
     # Save new file for deployment purposes and change pointer in object instance
     $f = (Save-AdfObjectAsFile -obj $o)

--- a/test/!RunAllTests.ps1
+++ b/test/!RunAllTests.ps1
@@ -1,11 +1,17 @@
 Param(
     [Parameter(Mandatory)]
-    [string]$folder
+    [string]$folder,
+
+    [Parameter(Mandatory=$false)]
+    [string]$TestFilenameFilter = "*",
+
+    [Parameter(Mandatory=$false)]
+    [Switch]$LocalTestsOnly
 )
 # $folder = 'X:\!WORK\GitHub\!SQLPlayer\azure.datafactory.tools\test'
 
 Write-Host "Setting new location: $folder"
-Set-Location "$folder"
+Push-Location "$folder"
 Get-Location | Out-Host
 
 # Add the module location to the value of the PSModulePath environment variable
@@ -16,13 +22,20 @@ Get-Location | Out-Host
 Get-PSRepository
 
 Write-Host "Installing PS modules..."
-Install-Module 'Az.DataFactory' -Force -MinimumVersion 1.8.0 -Repository 'PSGallery'
-Install-Module 'PSScriptAnalyzer' -Force
-Install-Module 'Pester' -Force -MinimumVersion 5.1.1
-Import-Module 'Pester'
-Import-Module 'PSScriptAnalyzer'
-Import-Module 'Az.DataFactory'
-Import-Module "$folder\azure.datafactory.tools.psd1"
+# Set a process scoped flag so we can run tests while developing without waiting for modules to load again
+if ($null -eq [Environment]::GetEnvironmentVariable("azure.datafactory.tools.unitTestInstalledModules", 'Process')){
+    [Environment]::SetEnvironmentVariable("azure.datafactory.tools.unitTestInstalledModules", $false, 'Process');
+}
+if ([Environment]::GetEnvironmentVariable("azure.datafactory.tools.unitTestInstalledModules", 'Process') -eq $false){
+    Install-Module 'Az.DataFactory' -Force -MinimumVersion 1.8.0 -Repository 'PSGallery'
+    Install-Module 'PSScriptAnalyzer' -Force
+    Install-Module 'Pester' -Force -MinimumVersion 5.1.1
+    Import-Module 'Pester'
+    Import-Module 'PSScriptAnalyzer'
+    Import-Module 'Az.DataFactory'
+    Import-Module "$folder\azure.datafactory.tools.psd1"
+    [Environment]::SetEnvironmentVariable("azure.datafactory.tools.unitTestInstalledModules", $true, 'Process');
+}
 Get-Module | Out-Host
 
 #v4
@@ -32,31 +45,34 @@ Get-Module | Out-Host
 #Invoke-Pester -Script "$testFile" -EnableExit -OutputFile "TEST-Results.xml" -OutputFormat NUnitXml
 
 #v5
-cls
-$r = $null
-$VerbosePreference = 'SilentlyContinue'
-$ErrorActionPreference = 'Stop'     #Important!!!
+#cls
+try{
+    $r = $null
+    $VerbosePreference = 'SilentlyContinue'
+    $ErrorActionPreference = 'Stop'     #Important!!!
 
-#Set-Location "X:\!WORK\GitHub\!SQLPlayer\azure.datafactory.tools\test"
-$configuration = [PesterConfiguration]::Default
-$configuration.Run.Exit = $true
-$configuration.Should.ErrorAction = 'Continue'
-$configuration.CodeCoverage.Enabled = $false
-$configuration.TestResult.OutputFormat = "NUnitXml"
-$configuration.TestResult.OutputPath = "TEST-Results.xml"
-$configuration.TestResult.Enabled = $true
-$configuration.Output.Verbosity = 'Detailed'
-#$configuration.Filter.ExcludeTag = 'Integration'
-$configuration.Run.Path = "$folder"
-$configuration.Run.TestExtension = "*.Tests.ps1"
-$configuration.Run.PassThru = $true
-$r = Invoke-Pester -Configuration $configuration
-$r.Result
+    #Set-Location "X:\!WORK\GitHub\!SQLPlayer\azure.datafactory.tools\test"
+    $configuration = [PesterConfiguration]::Default
+    $configuration.Run.Exit = $true
+    $configuration.Should.ErrorAction = 'Continue'
+    $configuration.CodeCoverage.Enabled = $false
+    $configuration.TestResult.OutputFormat = "NUnitXml"
+    $configuration.TestResult.OutputPath = "TEST-Results.xml"
+    $configuration.TestResult.Enabled = $true
+    $configuration.Output.Verbosity = 'Detailed'
+    if ($LocalTestsOnly) {
+        $configuration.Filter.ExcludeTag = 'Integration'
+    }
+    $configuration.Run.Path = "$folder"
+    $configuration.Run.TestExtension = "$TestFilenameFilter.Tests.ps1"
+    $configuration.Run.PassThru = $true
+    $r = Invoke-Pester -Configuration $configuration
+    $r.Result
 
-#$r.Failed
-#$r.Passed[0]
-$r.Failed | Format-Table -Property Result, StartLine, Duration, Path
+    #$r.Failed
+    #$r.Passed[0]
+    $r.Failed | Format-Table -Property Result, StartLine, Duration, Path
 
-
-
-
+} finally {
+    Pop-Location
+}

--- a/test/BigFactorySample2/deployment/config-array.csv
+++ b/test/BigFactorySample2/deployment/config-array.csv
@@ -1,0 +1,12 @@
+type,name,path,value
+pipeline,"Multiple Waits",activities[0].name,"Wait Number 1"
+
+# If we change the activity name before other nested properties, it changes the indexer, so we have to use the new name from then on...
+pipeline,"Multiple Waits",activities[1].typeProperties.ifTrueActivities[0].name,"Wait Number 2"
+pipeline,"Multiple Waits",activities["If Condition"].typeProperties.ifTrueActivities["Wait Number 2"].typeProperties.waitTimeInSeconds,22
+
+# If we change the activity name after the other nested properties we can just use the original name...
+pipeline,"Multiple Waits",activities["If Condition"].typeProperties.ifTrueActivities["Wait 3"].typeProperties.waitTimeInSeconds,33
+pipeline,"Multiple Waits",activities["If Condition"].typeProperties.ifTrueActivities["Wait 3"].name,"Wait Number 3"
+
+pipeline,"Multiple Waits",activities["Wait 4"].name,"Wait Number 4"

--- a/test/BigFactorySample2/pipeline/Multiple Waits.json
+++ b/test/BigFactorySample2/pipeline/Multiple Waits.json
@@ -1,0 +1,79 @@
+{
+    "name": "Multiple Waits",
+    "properties": {
+        "activities": [
+            {
+                "name": "Wait 1",
+                "type": "Wait",
+                "dependsOn": [],
+                "userProperties": [],
+                "typeProperties": {
+                    "waitTimeInSeconds": 1
+                }
+            },
+            {
+                "name": "If Condition",
+                "type": "IfCondition",
+                "dependsOn": [
+                    {
+                        "activity": "Wait 1",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "userProperties": [],
+                "typeProperties": {
+                    "expression": {
+                        "value": "@equals(1, 1)",
+                        "type": "Expression"
+                    },
+                    "ifTrueActivities": [
+                        {
+                            "name": "Wait 2",
+                            "type": "Wait",
+                            "dependsOn": [],
+                            "userProperties": [],
+                            "typeProperties": {
+                                "waitTimeInSeconds": 2
+                            }
+                        },
+                        {
+                            "name": "Wait 3",
+                            "type": "Wait",
+                            "dependsOn": [
+                                {
+                                    "activity": "Wait 2",
+                                    "dependencyConditions": [
+                                        "Succeeded"
+                                    ]
+                                }
+                            ],
+                            "userProperties": [],
+                            "typeProperties": {
+                                "waitTimeInSeconds": 3
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "Wait 4",
+                "type": "Wait",
+                "dependsOn": [
+                    {
+                        "activity": "If Condition1",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "userProperties": [],
+                "typeProperties": {
+                    "waitTimeInSeconds": 4
+                }
+            }
+        ],
+        "annotations": []
+    }
+}

--- a/test/Integration.Tests.ps1
+++ b/test/Integration.Tests.ps1
@@ -27,10 +27,12 @@ InModuleScope azure.datafactory.tools {
     $script:RootFolder = Join-Path -Path $script:TmpFolder -ChildPath (Split-Path -Path $script:SrcFolder -Leaf)
     $script:FinalOpt = New-AdfPublishOption
     # $RootFolder = "c:\Users\kamil\AppData\Local\Temp\24zet2bv.qvg\BigFactorySample2"
-
-    Remove-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$DataFactoryName" -Force
     Copy-Item -Path "$SrcFolder" -Destination "$TmpFolder" -Filter "*.csv" -Recurse:$true -Force 
-    #Invoke-Expression "explorer.exe '$TmpFolder'"
+
+    BeforeAll {
+        Remove-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$DataFactoryName" -Force
+        #Invoke-Expression "explorer.exe '$TmpFolder'"
+    }
 
     Describe 'Publish-AdfV2FromJson' -Tag 'Integration', 'adf' {
         # It 'Folder should exist' {
@@ -324,10 +326,11 @@ InModuleScope azure.datafactory.tools {
             }
         }
         Context 'When called and 3 triggers are in service' {
-            Mock Stop-AzDataFactoryV2Trigger { }
-            $script:adf = Import-AdfFromFolder -FactoryName $script:DataFactoryName -RootFolder "$RootFolder"
-            $script:adf.ResourceGroupName = "$ResourceGroupName";
-
+            BeforeAll {
+                Mock Stop-AzDataFactoryV2Trigger { }
+                $script:adf = Import-AdfFromFolder -FactoryName $script:DataFactoryName -RootFolder "$RootFolder"
+                $script:adf.ResourceGroupName = "$ResourceGroupName";
+            }
             It 'Should disable only those active' {
                 Stop-Triggers -adf $script:adf
                 $allTriggers = Get-AzDataFactoryV2Trigger -DataFactoryName "$DataFactoryName" -ResourceGroupName "$ResourceGroupName"
@@ -335,7 +338,5 @@ InModuleScope azure.datafactory.tools {
                 Assert-MockCalled Stop-AzDataFactoryV2Trigger -Times $activeTriggers.Count
             }
         }
-
-
     }
 }

--- a/test/Triggers.Tests.ps1
+++ b/test/Triggers.Tests.ps1
@@ -27,11 +27,12 @@ InModuleScope azure.datafactory.tools {
     }
     $script:triggerName = 'TR_AlwaysDisabled'
     $script:DoNotStopStartExcludedTriggers = $true
-
-    Remove-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$DataFactoryName" -Force
     Copy-Item -Path "$SrcFolder" -Destination "$TmpFolder" -Filter "*.csv" -Recurse:$true -Force 
-    #Invoke-Expression "explorer.exe '$TmpFolder'"
 
+    BeforeAll {
+        Remove-AzDataFactoryV2 -ResourceGroupName "$ResourceGroupName" -Name "$DataFactoryName" -Force
+        #Invoke-Expression "explorer.exe '$TmpFolder'"
+    }
     
 
 

--- a/test/Update-PropertiesFromFile.Tests.ps1
+++ b/test/Update-PropertiesFromFile.Tests.ps1
@@ -197,6 +197,46 @@ InModuleScope azure.datafactory.tools {
             }
         }
 
+        Context 'When called and CSV has array indexers in object name column' {
+            It 'Should complete' {
+                # Changing activity names means we can index into it if another test already ran, so reload the files
+                Copy-Item -Path "$SrcFolder" -Destination "$TmpFolder" -Filter "*.*" -Recurse:$true -Force
+                $script:adf = Import-AdfFromFolder -FactoryName "xyz" -RootFolder "$RootFolder"
+                $script:option = New-AdfPublishOption
+                $script:adf.PublishOptions = $option
+                {
+                    Update-PropertiesFromFile -adf $script:adf -stage "array"
+                } | Should -Not -Throw
+            }
+        }
+        Context 'When called and CSV has array indexers in object name column' {
+            BeforeEach {
+                Mock Update-PropertiesForObject { return 0; }
+            }
+            It 'Should execute Update-PropertiesForObject 4 times' {
+                Update-PropertiesFromFile -adf $script:adf -stage "array"
+                Assert-MockCalled Update-PropertiesForObject -Times 4
+            }
+        }
+        Context 'When called and CSV has array indexers in object name column' {
+            It 'Should update properties of correct activities' {
+                # Changing activity names means we can index into it if another test already ran, so reload the files
+                Copy-Item -Path "$SrcFolder" -Destination "$TmpFolder" -Filter "*.*" -Recurse:$true -Force
+                $script:adf = Import-AdfFromFolder -FactoryName "xyz" -RootFolder "$RootFolder"
+                $script:option = New-AdfPublishOption
+                $script:adf.PublishOptions = $option
+
+                Update-PropertiesFromFile -adf $script:adf -stage "array"
+                $t = Get-AdfObjectByName -adf $script:adf -name "Multiple Waits" -type "Pipeline"
+                $t.Body.properties.activities[0].name | Should -Be "Wait Number 1"
+                $t.Body.properties.activities[1].typeProperties.ifTrueActivities[0].name | Should -Be "Wait Number 2"
+                $t.Body.properties.activities[1].typeProperties.ifTrueActivities[0].typeProperties.waitTimeInSeconds | Should -Be 22
+                $t.Body.properties.activities[1].typeProperties.ifTrueActivities[1].name | Should -Be "Wait Number 3"
+                $t.Body.properties.activities[1].typeProperties.ifTrueActivities[1].typeProperties.waitTimeInSeconds | Should -Be 33
+                $t.Body.properties.activities[2].name | Should -Be "Wait Number 4"
+            }
+        }
+
         Context 'When called and CSV contains global parameters to be replaced' {
             It 'Should complete' {
                 $script:adf = Import-AdfFromFolder -FactoryName "xyz" -RootFolder "$RootFolder"

--- a/test/Update-PropertiesFromFile.Tests.ps1
+++ b/test/Update-PropertiesFromFile.Tests.ps1
@@ -27,7 +27,7 @@ InModuleScope azure.datafactory.tools {
 
         Context 'When called without parameters' {
             It 'Should throw an error' {
-                { Update-PropertiesFromFile } | Should -Throw 
+                { Update-PropertiesFromFile -Force } | Should -Throw 
             }
         }
 


### PR DESCRIPTION
Hi Kamil

Here's the PR for Issue #98.

Added the option to update values on an object in an array by indexing into it using the name of the item. There are unit tests for the new functionality. The old functionality of using integer based indexing into the array still works too.

The implementation has a few limitations:
- Currently only arrays where all items within the array have a name property can be accessed using the name as the indexer. This is because it is implemented using dictionaries internally, and therefore requires a key. It is easy to add any other properties we may want to use as a key, there is an array of values to check, first value is highest priority.
- There is an edge case where changing the name of the item you access via a name based index means subsequent updates in the csv/json file must then use the new name. They are applied in order, again a limitation of the way it extends existing functionality. This edge case is covered in the test data.

The 3rd commit contains a few changes to the test structure that I was using to make it easier to debug locally. They should not change the way tests are run for anyone else or by CI, but make it a bit faster to debug from VSCode.

I have run all the unit tests locally, I have not run the integration tests yet.