### PR TITLE
Fixes for bug 147

### DIFF
--- a/private/ConvertFrom-OrderedHashTablesToArrays.ps1
+++ b/private/ConvertFrom-OrderedHashTablesToArrays.ps1
@@ -24,15 +24,15 @@ function ConvertFrom-OrderedHashTablesToArrays {
             
                 Write-Verbose "Converting ordered hash table to array";
 
-                # First convert each item in the array to have ordered hashtables instead of arrays if required
+                # First convert each item in the array to have arrays instead of ordered hashtables if required
                 for ($i=0; $i -lt $Item.$prop.Count; $i++ ){
                     $Item.$prop[$i] = ConvertFrom-OrderedHashTablesToArrays -Item $Item.$prop[$i];
                 }
-                # Then convert the actual array to a ordered hashtables
+                # Then convert the actual ordered hashtables back to an array
 
                 # Without the ForEach-Object we get a OrderedDictionaryKeyValueCollection back, which is not too useful. We need an array, or the JSON
                 # gets saved using the keys as properties instead of an array. The foreeach unboxes back to an array for us.
-                $Item.$prop = $Item.$prop.Values | ForEach-Object { $_ };
+                $Item.$prop = @($Item.$prop.Values | ForEach-Object { $_ });
             }
             elseif ( $Item.$prop.GetType().Name -eq "PSCustomObject" ) {
                 Write-Verbose "Converting PSCustomObject property using a recursive function call...";

--- a/test/BigFactorySample2/pipeline/Multiple Waits.json
+++ b/test/BigFactorySample2/pipeline/Multiple Waits.json
@@ -54,6 +54,17 @@
                                 "waitTimeInSeconds": 3
                             }
                         }
+                    ],
+                    "ifFalseActivities": [
+                        {
+                            "name": "Wait 5",
+                            "type": "Wait",
+                            "dependsOn": [],
+                            "userProperties": [],
+                            "typeProperties": {
+                                "waitTimeInSeconds": 2
+                            }
+                        }
                     ]
                 }
             },


### PR DESCRIPTION
The Conversion back from an OrderedHashSet to an array was allowing unboxing of an array with a single item, which stripped the array brackets from the JSON. The array is now forced, meaning the output JSON will always have an array if the source JSON had an array.