### PR TITLE
Fixing : Deploying global parameters reset Network Status

### DIFF
--- a/private/Update-GlobalParameters.ps1
+++ b/private/Update-GlobalParameters.ps1
@@ -31,7 +31,7 @@ param
             #$newGlobalParameters.Values | Out-Host
 
             Write-Verbose "Updating $($newGlobalParameters.Count) global parameters..."
-            Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+            Set-AzDataFactoryV2 -InputObject $targetAdf -Force -PublicNetworkAccess $targetAdf.PublicNetworkAccess| Out-Null
             Write-Host "Update of $($newGlobalParameters.Count) global parameters complete."
         }
     }


### PR DESCRIPTION
Update: Deploying global parameters resets publicNetworkAccess setting on factory

https://github.com/SQLPlayer/azure.datafactory.tools/issues/138
https://github.com/MicrosoftDocs/azure-docs/issues/95044