### PR TITLE
Edit Publish-AdfV2UsingArm to use ConvertTo-AdfCollection for collections

### DIFF
--- a/private/ConvertTo-AdfCollection.ps1
+++ b/private/ConvertTo-AdfCollection.ps1
@@ -1,0 +1,26 @@
+function ConvertTo-AdfCollection {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)] 
+        [String] $AzType
+    )
+
+    $resType = ""
+
+    switch -Exact ($AzType)
+    {
+        'Microsoft.DataFactory/factories/pipelines'                                      { $resType = 'Pipelines' }
+        'Microsoft.DataFactory/factories/linkedservices'                                 { $resType = 'LinkedServices' }
+        'Microsoft.DataFactory/factories/datasets'                                       { $resType = 'Datasets' }
+        'Microsoft.DataFactory/factories/dataflows'                                      { $resType = 'Dataflows' }
+        'Microsoft.DataFactory/factories/triggers'                                       { $resType = 'Triggers' }
+        'Microsoft.DataFactory/factories/integrationruntimes'                            { $resType = 'IntegrationRuntimes' }
+        'Microsoft.DataFactory/factories'                                                { $resType = 'Factories' }
+        'Microsoft.DataFactory/factories/managedVirtualNetworks'                         { $resType = 'ManagedVirtualNetworks' }
+        'Microsoft.DataFactory/factories/managedVirtualNetworks/managedPrivateEndpoints' { $resType = 'ManagedPrivateEndpoints' }
+        'Microsoft.DataFactory/factories/credentials'                                    { $resType = 'Credentials' }
+        default                                                                          { Write-Error "ADFT0030: AzType '$AzType' is not supported." }
+    }
+
+    return $resType
+}

--- a/public/Publish-AdfV2UsingArm.ps1
+++ b/public/Publish-AdfV2UsingArm.ps1
@@ -150,7 +150,8 @@ function Publish-AdfV2UsingArm {
         $o.Adf = $adf
         $o.Body = $_
         $adf.Pipelines.Add($o)
-        $collectionName = $ArmType.Substring(32)
+        
+        $collectionName = ConvertTo-AdfCollection $ArmType
         Invoke-Expression "`$adf.$collectionName.Add(`$o)"
     }
     if ($armParam.parameters.factoryName.value -ne $DataFactoryName) {


### PR DESCRIPTION
#185 and #184 

And my issue #185 from the repo: [azure.datafactory.devops](https://github.com/Azure-Player/azure.datafactory.devops)


I am using the BuildADFTask@1 to compile the project into an arm template then later using the DeployAdfFromArmTask@0 to try and deploy it.

This line was pulling in the full path for mpes and not the collection name ManagedPrivateEndpoints:
$collectionName = $ArmType.Substring(32) 

Which then this line: 
Invoke-Expression "$adf.$collectionName.Add($o)"

to try and invoke:
$adf.managedVirtualNetworks/managedPrivateEndpoints.Add($o)

 