### PR TITLE
Starting blob event trigger fails with 'Resource cannot be updated during provisioning' - now waits for provisioning to complete before retrying #484

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -1,38 +1,35 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Login via Az module
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
-        creds: ${{secrets.AZURE_CREDENTIALS}}
-        enable-AzPSSession: true 
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        enable-AzPSSession: true
 
     - name: Run Azure PowerShell script
-      uses: azure/powershell@v1
+      uses: azure/powershell@v2
       with:
         inlineScript: |
-          test/!RunAllTests.ps1 -folder 'D:/a/azure.datafactory.tools/azure.datafactory.tools/' -TestFilenameFilter "*"
+          test/!RunAllTests.ps1 -folder '${{ github.workspace }}/' -TestFilenameFilter "*"
         azPSVersion: "latest"

--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -31,5 +31,5 @@ jobs:
       uses: azure/powershell@v2
       with:
         inlineScript: |
-          test/!RunAllTests.ps1 -folder '${{ github.workspace }}/' -TestFilenameFilter "*"
+          test/!RunAllTests.ps1 -folder '${{ github.workspace }}/' -TestFilenameFilter "*" -InstallModules
         azPSVersion: "latest"

--- a/azure.datafactory.tools.psd1
+++ b/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.12.0'
+    ModuleVersion = '1.15.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -27,7 +27,7 @@
     CompanyName = 'SQLPlayer'
     
     # Copyright statement for this module
-    Copyright = '(c) 2020-2025 Kamil Nowinski. All rights reserved.'
+    Copyright = '(c) 2020-2026 Kamil Nowinski. All rights reserved.'
     
     # Description of the functionality provided by this module
     Description = 'PowerShell module to help with CI&CD for Azure Data Factory, mainly to publish to ADF service in multiple environments. Check https://github.com/Azure-Player/azure.datafactory.tools/ & https://azureplayer.net/adf/'

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.15.0] - 2026-05-26
+### Fixed
+* Starting blob event trigger fails with 'Resource cannot be updated during provisioning' - now waits for provisioning to complete before retrying #484, #474, #463
+
+## [1.14.0] - 2025-10-24
+### Added
+* New input parameters for Get-AdfDocDiagram function: Include, Exclude.
+
+## [1.13.1] - 2025-10-19
+### Fixed
+* Fixed trigger start retry logic to exit immediately on successful start instead of running all 5 attempts #465
+* Fixed CSV parametrization line count reporting when CSV contains empty lines #446
+
+## [1.13.0] - 2025-05-20
+### Fixed
+* Adopted to breaking change in Az.Accounts v5.0 with Get-AzAccessToken that doesn't support String anymore #449
+
 ## [1.12.0] - 2025-03-20
 ### Added
 * Error during the import when required Az.Resource module is not loaded #336

--- a/private/Start-Trigger.ps1
+++ b/private/Start-Trigger.ps1
@@ -19,17 +19,37 @@ function Start-Trigger {
                 -DataFactoryName $DataFactoryName `
                 -Name $Name `
                 -Force | Out-Null
+            break
         }
         catch {
+            $errMsg = $_.Exception.Message
             if ($i -lt $attempts)
             {
-                Write-Verbose "Attempt #$i of starting trigger failed. Retry in 2 seconds."
-                Start-Sleep -Seconds 2 
-            } 
-            else 
+                if ($errMsg -like "*cannot be updated during provisioning*") {
+                    Write-Verbose "Attempt #${i}: Trigger '$Name' is still provisioning. Waiting for provisioning to complete..."
+                    $provisioningTimeout = 300
+                    $pollInterval = 10
+                    $elapsed = 0
+                    while ($elapsed -lt $provisioningTimeout) {
+                        Start-Sleep -Seconds $pollInterval
+                        $elapsed += $pollInterval
+                        $trigger = Get-AzDataFactoryV2Trigger `
+                            -ResourceGroupName $ResourceGroupName `
+                            -DataFactoryName $DataFactoryName `
+                            -Name $Name
+                        $provState = $trigger.Properties.ProvisioningState
+                        Write-Verbose "Trigger provisioning state: $provState ($elapsed sec elapsed)"
+                        if ($provState -ne 'Provisioning') { break }
+                    }
+                } else {
+                    Write-Verbose "Attempt #$i of starting trigger failed. Retry in 2 seconds."
+                    Start-Sleep -Seconds 2
+                }
+            }
+            else
             {
                 Write-Host "Failed starting trigger after $attempts attempts."
-                Write-Warning -Message $_.Exception.Message
+                Write-Warning -Message $errMsg
             }
         }
     }

--- a/test/Start-Trigger.Tests.ps1
+++ b/test/Start-Trigger.Tests.ps1
@@ -25,18 +25,38 @@ InModuleScope azure.datafactory.tools {
 
         It 'Should retry after the first failure' {
             $script:attempts = 2
-            Mock Start-AzDataFactoryV2Trigger { $attempts--; if ($attempts -eq 0) { Write-Host 'OK' } else { Write-Error 'BadRequest' } }
-            Start-Trigger -ResourceGroupName 'rg' -DataFactoryName 'adf' -Name 'tr1' 
+            Mock Start-AzDataFactoryV2Trigger { $attempts--; if ($attempts -eq 0) { Write-Host 'OK' } else { throw 'BadRequest' } }
+            Start-Trigger -ResourceGroupName 'rg' -DataFactoryName 'adf' -Name 'tr1'
             Assert-MockCalled Start-AzDataFactoryV2Trigger -Times 2
         }
 
         It 'Should retry max 5 times when failure' {
-            Mock Start-AzDataFactoryV2Trigger { Write-Error 'BadRequest' }
-            Start-Trigger -ResourceGroupName 'rg' -DataFactoryName 'adf' -Name 'tr1' 
+            Mock Start-AzDataFactoryV2Trigger { throw 'BadRequest' }
+            Start-Trigger -ResourceGroupName 'rg' -DataFactoryName 'adf' -Name 'tr1'
             Assert-MockCalled Start-AzDataFactoryV2Trigger -Times 5
         }
 
-    } 
+        It 'Should wait for provisioning and retry when trigger cannot be updated during provisioning' {
+            $script:startAttempt = 0
+            Mock Start-AzDataFactoryV2Trigger {
+                $script:startAttempt++
+                if ($script:startAttempt -eq 1) { throw 'BadRequest: Resource cannot be updated during provisioning' }
+            }
+            $script:getAttempt = 0
+            Mock Get-AzDataFactoryV2Trigger {
+                $script:getAttempt++
+                $state = if ($script:getAttempt -eq 1) { 'Provisioning' } else { 'Succeeded' }
+                return [PSCustomObject]@{ Properties = [PSCustomObject]@{ ProvisioningState = $state } }
+            }
+            Mock Start-Sleep {}
+
+            Start-Trigger -ResourceGroupName 'rg' -DataFactoryName 'adf' -Name 'tr1'
+
+            Assert-MockCalled Start-AzDataFactoryV2Trigger -Times 2
+            Assert-MockCalled Get-AzDataFactoryV2Trigger -Times 2
+        }
+
+    }
 }
 
 


### PR DESCRIPTION
`private/Start-Trigger.ps1`

- Added break after a successful Start-AzDataFactoryV2Trigger call (avoids 4 redundant calls that previously always ran)
- On failure, checks if the error is "cannot be updated during provisioning" — the Azure error returned when a BlobEventsTrigger is still setting up its Event Grid subscription
- If it is, polls Get-AzDataFactoryV2Trigger every 10 seconds (up to 5 minutes) until Properties.ProvisioningState is no longer 'Provisioning', then retries the start
- All other errors keep the existing 2-second retry behaviour

`test/Start-Trigger.Tests.ps1`

- Updated existing mocks from Write-Error (non-terminating, not caught by catch) to throw (terminating, matches real Azure cmdlet behaviour)
- Added a new test that verifies: provisioning error → polls twice (Provisioning → Succeeded) → retries start successfully