### PR TITLE
Fixed ClientAssertionCredential authentication failure for federated identity (OIDC) credentials by removing redundant `Get-AzAccessToken` calls in `Get-AzDFV2Credential` and `Remove-AdfObjectRestAPI` #492

### DIFF
--- a/azure.datafactory.tools.psd1
+++ b/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.15.0'
+    ModuleVersion = '1.16.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.16.0] - 2026-06-06
+
+### Fixed
+
+* Fixed ClientAssertionCredential authentication failure for federated identity (OIDC) credentials by removing redundant `Get-AzAccessToken` calls in `Get-AzDFV2Credential` and `Remove-AdfObjectRestAPI` #492
+
 ## [1.15.0] - 2026-05-26
 ### Added
 * Credential type of ADF objects is now supported for deployment via REST API

--- a/private/Get-AzDFV2Credential.ps1
+++ b/private/Get-AzDFV2Credential.ps1
@@ -5,13 +5,6 @@ function Get-AzDFV2Credential {
     )
     Write-Debug "BEGIN: Get-AzDFV2Credential"
 
-    # Retrieve all credentials via API without parsing
-    $token = Get-AzAccessToken -ResourceUrl 'https://management.azure.com'
-    $tokenStr = [System.Net.NetworkCredential]::new('', $token.Token).Password
-    $authHeader = @{
-        'Content-Type'  = 'application/json'
-        'Authorization' = 'Bearer ' + $tokenStr
-    }
     $url = "$($script:BaseApiUrl)$($adfi.DataFactoryId)/credentials?api-version=2018-06-01"
 
     # Retrieve all credentials via Rest API

--- a/private/Remove-AdfObjectRestAPI.ps1
+++ b/private/Remove-AdfObjectRestAPI.ps1
@@ -8,16 +8,10 @@ function Remove-AdfObjectRestAPI {
 
     Write-Debug "BEGIN: Remove-AdfObjectRestAPI()"
 
-    $token = Get-AzAccessToken -ResourceUrl 'https://management.azure.com'
-    $tokenStr = [System.Net.NetworkCredential]::new('', $token.Token).Password
-    $authHeader = @{
-        'Content-Type'  = 'application/json'
-        'Authorization' = 'Bearer ' + $tokenStr
-    }
     $url = "$($script:BaseApiUrl)$($adfInstance.Id)/$type_plural/$($name)?api-version=2018-06-01"
 
     # Delete given object via Rest API
-    $r = Invoke-AzRestMethod -Method 'DELETE' -Uri $url #-Headers $authHeader -ContentType "application/json"
+    $r = Invoke-AzRestMethod -Method 'DELETE' -Uri $url
     if ($r.StatusCode -ne 200) {
         Write-Error -Message "Unexpected response code: $($r.StatusCode) from the API."
     }

--- a/test/Get-AzDFV2Credential.Tests.ps1
+++ b/test/Get-AzDFV2Credential.Tests.ps1
@@ -20,9 +20,6 @@ InModuleScope azure.datafactory.tools {
             BeforeEach {
                 $script:adfi = [PSCustomObject]@{ DataFactoryId = '/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.DataFactory/factories/adf1' }
 
-                Mock Get-AzAccessToken {
-                    return [PSCustomObject]@{ Token = 'fake-token-abc' }
-                }
                 Mock Invoke-AzRestMethod {
                     return [PSCustomObject]@{ StatusCode = 200; Content = '{"value":[]}' }
                 }
@@ -31,11 +28,6 @@ InModuleScope azure.datafactory.tools {
             It 'Should return an empty list' {
                 $result = Get-AzDFV2Credential -adfi $script:adfi
                 @($result).Count | Should -Be 0
-            }
-
-            It 'Should call Get-AzAccessToken once' {
-                Get-AzDFV2Credential -adfi $script:adfi
-                Assert-MockCalled Get-AzAccessToken -Times 1 -Exactly
             }
 
             It 'Should call Invoke-AzRestMethod once' {
@@ -66,9 +58,6 @@ InModuleScope azure.datafactory.tools {
                 $cred2 = [PSCustomObject]@{ name = 'cred2'; type = 'Microsoft.DataFactory/factories/credentials'; properties = @{} }
                 $script:credJson = @{ value = @($cred1, $cred2) } | ConvertTo-Json -Depth 5
 
-                Mock Get-AzAccessToken {
-                    return [PSCustomObject]@{ Token = 'fake-token-abc' }
-                }
                 Mock Invoke-AzRestMethod {
                     return [PSCustomObject]@{ StatusCode = 200; Content = $script:credJson }
                 }
@@ -97,9 +86,6 @@ InModuleScope azure.datafactory.tools {
             BeforeEach {
                 $script:adfi = [PSCustomObject]@{ DataFactoryId = '/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.DataFactory/factories/adf1' }
 
-                Mock Get-AzAccessToken {
-                    return [PSCustomObject]@{ Token = 'fake-token-abc' }
-                }
                 Mock Invoke-AzRestMethod { throw 'Unauthorized' }
             }
 


### PR DESCRIPTION
Fixed #492